### PR TITLE
Non-root user in container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,24 @@
+FROM debian:latest
+
+ARG CONTAINER_USER="developer"
+ARG HOST_USER=1000
+ARG HOST_GROUP=1000
+
+RUN apt update
+RUN apt upgrade
+
+RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt install -y sudo
+
+# Delete user with given UID if it exists
+RUN userdel $(id -nu $HOST_USER) || true
+# Delete group with given GID if it exists
+RUN groupdel $(awk -F: '$3 == $HOST_GROUP' /etc/group | cut -d: -f1) || true
+
+# Create the user
+RUN groupadd --gid $HOST_GROUP $CONTAINER_USER \
+    && useradd -rm -d /home/$CONTAINER_USER -s /usr/bin/bash -g $CONTAINER_USER -G sudo -u $HOST_USER $CONTAINER_USER \
+    && mkdir -p /etc/sudoers.d \
+    && echo $CONTAINER_USER ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$CONTAINER_USER \
+    && chmod 0440 /etc/sudoers.d/$CONTAINER_USER
+
+ENTRYPOINT /usr/bin/bash

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,10 @@
 {
 	"name": "Build tools",
-	"image": "debian:latest",
+	"build": {
+        "dockerfile": "Dockerfile"
+    },
 	"postCreateCommand": "${PWD}/.devcontainer/init.sh",
+	"remoteUser": "developer",
 	"features": {
 		"ghcr.io/greybeaglelinux/image-dev-features/imagedev:latest": {}
 	},

--- a/.devcontainer/init.sh
+++ b/.devcontainer/init.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+ln -sf /build/venv .venv
+
+UID=$(id -u)
+if [ $UID -ne 0 ]; then
+    echo "Fixing permissions of /build"
+    sudo chown -R $(id -un):$(id -gn) /build
+fi
+
 # install the build tools
 source /build/venv/bin/activate && pip install -e .
 
@@ -7,4 +15,3 @@ source /build/venv/bin/activate && pip install -e .
 source /build/venv/bin/activate && pip install -r dev-requirements.txt
 
 ln -sf /build build
-ln -sf /build/venv .venv

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,8 @@
 
 /tmp
-/book
 
-book
 .venv
+/build
 
 log.html
 output.xml


### PR DESCRIPTION
# Changes

- Build dev container from docker file.
- Add "developer" user to container.
- Adapt init.sh to move ownership of /build to developer.

# Dependencies:

none

# Tests results

N/A

# Developer Checklist:

- [x] Test: Changes are tested
- N/A Doc: Documentation has been updated 
- [x] Git: Informative git commit message(s)
- N/A Issue: If a related GitHub issue exists, linking is done

# Reviewer checklist:

- [ ] Review: Changes are reviewed
- [ ] Review: Tested by the reviewer
